### PR TITLE
Spell out package paths in test cases

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,7 +11,7 @@ import unittest
 from enum import Enum
 from typing import Dict, List, NamedTuple, Optional
 
-from ..cli import (
+from frldistml.scaffold.cli import (
     ScaffoldHelpFormatter,
     arguments_from_named_tuple,
     compose_type_arguments,

--- a/tests/test_indexed_dataset.py
+++ b/tests/test_indexed_dataset.py
@@ -20,10 +20,10 @@ import numpy as np
 from mock import patch
 from torch.utils.data import Dataset
 
-from ..indexed_dataset import IndexedDatasetWriterFactory, MultifieldIndexedDataset
-from ..storage import StoragePath
-from ..storage_layers.dataset import IndexedDatasetReader, np_types
-from ..storage_layers.posix_storage import PosixIndexedDatasetReader
+from frldistml.scaffold.indexed_dataset import IndexedDatasetWriterFactory, MultifieldIndexedDataset
+from frldistml.scaffold.storage import StoragePath
+from frldistml.scaffold.storage_layers.dataset import IndexedDatasetReader, np_types
+from frldistml.scaffold.storage_layers.posix_storage import PosixIndexedDatasetReader
 
 
 FIELD = "TEST"

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -9,8 +9,8 @@ import unittest
 
 import torch
 
-from ..solver import create_lr_scheduler
-from ..types import Mode, OptAlgorithm, OptimOpts, RunOpts
+from frldistml.scaffold.solver import create_lr_scheduler
+from frldistml.scaffold.types import Mode, OptAlgorithm, OptimOpts, RunOpts
 
 
 class TestSolver(unittest.TestCase):

--- a/tests/test_watchdog_timer.py
+++ b/tests/test_watchdog_timer.py
@@ -10,7 +10,7 @@ from time import sleep
 from unittest import TestCase
 from unittest.mock import patch
 
-from ..watchdog_timer import WatchdogTimer
+from frldistml.scaffold.watchdog_timer import WatchdogTimer
 
 
 class WatchdogTimerTest(TestCase):


### PR DESCRIPTION
Some of the existing imports are using relative path. Change them to spell out the full package path.